### PR TITLE
Seed randomness in treeview tests

### DIFF
--- a/tests/test_treeview/barchart_and_piechart_faces.py
+++ b/tests/test_treeview/barchart_and_piechart_faces.py
@@ -6,35 +6,47 @@ from ete4.treeview import faces, TreeStyle, COLOR_SCHEMES
 
 schema_names = sorted(COLOR_SCHEMES.keys())
 
-def layout(node):
+def layout(node, rng):
     if node.is_leaf:
-        F= faces.PieChartFace([10,10,10,10,10,10,10,10,10,4,6],
-                              colors=COLOR_SCHEMES["set3"],
-                              width=50, height=50)
+        F = faces.PieChartFace(
+            [10, 10, 10, 10, 10, 10, 10, 10, 10, 4, 6],
+            colors=COLOR_SCHEMES["set3"],
+            width=50,
+            height=50,
+        )
         F.border.width = None
         F.opacity = 0.8
-        faces.add_face_to_node(F,node, 0, position="branch-right")
+        faces.add_face_to_node(F, node, 0, position="branch-right")
 
-        F= faces.PieChartFace([10,20,5,5,60],
-                              colors=COLOR_SCHEMES[random.sample(schema_names, 1)[0]],
-                              width=100, height=40)
+        schema = rng.choice(schema_names)
+        F = faces.PieChartFace(
+            [10, 20, 5, 5, 60],
+            colors=COLOR_SCHEMES[schema],
+            width=100,
+            height=40,
+        )
         F.border.width = None
         F.opacity = 0.8
-        faces.add_face_to_node(F,node, 0, position="branch-right")
+        faces.add_face_to_node(F, node, 0, position="branch-right")
     else:
-        F= faces.BarChartFace([40,20,70,100,30,40,50,40,70,-12], min_value=-12,
-                              colors=COLOR_SCHEMES["spectral"],
-                              labels = "aaa,bbb,cccccc,dd,eeee,ffff,gg,HHH,II,JJJ,KK".split(","))
-        faces.add_face_to_node(F,node, 0, position="branch-top")
+        F = faces.BarChartFace(
+            [40, 20, 70, 100, 30, 40, 50, 40, 70, -12],
+            min_value=-12,
+            colors=COLOR_SCHEMES["spectral"],
+            labels="aaa,bbb,cccccc,dd,eeee,ffff,gg,HHH,II,JJJ,KK".split(","),
+        )
+        faces.add_face_to_node(F, node, 0, position="branch-top")
         F.background.color = "#eee"
 
-def get_example_tree():
+def get_example_tree(rng=None):
+    if rng is None:
+        rng = random
     t = Tree()
     ts = TreeStyle()
-    ts.layout_fn = layout
+    ts.layout_fn = lambda node: layout(node, rng)
     ts.mode = "r"
     ts.show_leaf_name = False
-    t.populate(10)
+    t.populate(10, dist_fn=rng.random, support_fn=rng.random)
     return t, ts
 
 if __name__ == '__main__':

--- a/tests/test_treeview/bubble_map.py
+++ b/tests/test_treeview/bubble_map.py
@@ -16,14 +16,16 @@ def layout(node):
         # And place as a float face over the tree
         faces.add_face_to_node(C, node, 0, position="float")
 
-def get_example_tree():
+def get_example_tree(rng=None):
+    if rng is None:
+        rng = random
     # Random tree
     t = Tree()
-    t.populate(20, dist_fn=random.random, support_fn=random.random)
+    t.populate(20, dist_fn=rng.random, support_fn=rng.random)
 
     # Some random features in all nodes
     for n in t.traverse():
-        n.add_props(weight=random.randint(0, 50))
+        n.add_props(weight=rng.randint(0, 50))
 
     # Create an empty TreeStyle
     ts = TreeStyle()

--- a/tests/test_treeview/face_rotation.py
+++ b/tests/test_treeview/face_rotation.py
@@ -1,13 +1,13 @@
-from random import randint
+import random
 
 from ete4 import Tree
 from ete4.treeview import TreeStyle, add_face_to_node, TextFace
 
 
-def rotation_layout(node):
+def rotation_layout(node, rng):
     if node.is_leaf:
         F = TextFace(node.name, tight_text=True)
-        F.rotation = randint(0, 360)
+        F.rotation = rng.randint(0, 360)
         add_face_to_node(TextFace("third"), node, column=8, position="branch-right")
         add_face_to_node(TextFace("second"), node, column=2, position="branch-right")
         add_face_to_node(F, node, column=0, position="branch-right")
@@ -15,13 +15,15 @@ def rotation_layout(node):
         F.border.width = 1
         F.inner_border.width = 1
 
-def get_example_tree():
+def get_example_tree(rng=None):
+    if rng is None:
+        rng = random
     t = Tree()
-    t.populate(10)
+    t.populate(10, dist_fn=rng.random, support_fn=rng.random)
     ts = TreeStyle()
     ts.rotation = 45
     ts.show_leaf_name = False
-    ts.layout_fn = rotation_layout
+    ts.layout_fn = lambda node: rotation_layout(node, rng)
 
     return t, ts
 

--- a/tests/test_treeview/item_faces.py
+++ b/tests/test_treeview/item_faces.py
@@ -7,8 +7,14 @@ from ete4.treeview import faces, TreeStyle, NodeStyle, Face
 
 # We will need to create Qt4 items
 from ete4.treeview.qt import QtCore, Qt
-from ete4.treeview.qt import QGraphicsRectItem, QGraphicsSimpleTextItem, \
-    QGraphicsEllipseItem, QColor, QPen, QBrush
+from ete4.treeview.qt import (
+    QGraphicsRectItem,
+    QGraphicsSimpleTextItem,
+    QGraphicsEllipseItem,
+    QColor,
+    QPen,
+    QBrush,
+)
 
 class InteractiveItem(QGraphicsRectItem):
     def __init__(self, *arg, **karg):
@@ -40,10 +46,12 @@ class InteractiveItem(QGraphicsRectItem):
             self.label.setVisible(False)
 
 
-def random_color(h=None):
+def random_color(h=None, rng=None):
     """Generates a random color in RGB format."""
-    if not h:
-        h = random.random()
+    if rng is None:
+        rng = random
+    if h is None:
+        h = rng.random()
     s = 0.5
     l = 0.5
     return _hls2hex(h, l, s)
@@ -52,7 +60,7 @@ def _hls2hex(h, l, s):
     return '#%02x%02x%02x' %tuple(map(lambda x: int(x*255),
                                       colorsys.hls_to_rgb(h, l, s)))
 
-def ugly_name_face(node, *args, **kargs):
+def ugly_name_face(node, rng, *args, **kargs):
     """ This is my item generator. It must receive a node object, and
     returns a Qt4 graphics item that can be used as a node face.
     """
@@ -82,7 +90,7 @@ def ugly_name_face(node, *args, **kargs):
     ellipse = QGraphicsEllipseItem(masterItem.rect())
     ellipse.setParentItem(masterItem)
     # Change ellipse color
-    ellipse.setBrush(QBrush(QColor( random_color())))
+    ellipse.setBrush(QBrush(QColor(random_color(rng=rng))))
 
     # Add node name within the ellipse
     text = QGraphicsSimpleTextItem(node.name)
@@ -97,22 +105,24 @@ def ugly_name_face(node, *args, **kargs):
 
     return masterItem
 
-def master_ly(node):
+def master_ly(node, rng):
     if node.is_leaf:
         # Create an ItemFAce. First argument must be the pointer to
         # the constructor function that returns a QGraphicsItem. It
         # will be used to draw the Face. Next arguments are arbitrary,
         # and they will be forwarded to the constructor Face function.
-        F = faces.DynamicItemFace(ugly_name_face, 100, 50)
+        F = faces.DynamicItemFace(ugly_name_face, rng, 100, 50)
         faces.add_face_to_node(F, node, 0, position="aligned")
 
-def get_example_tree():
+def get_example_tree(rng=None):
+    if rng is None:
+        rng = random
 
     t = Tree()
-    t.populate(8)
+    t.populate(8, dist_fn=rng.random, support_fn=rng.random)
 
     ts = TreeStyle()
-    ts.layout_fn = master_ly
+    ts.layout_fn = lambda node: master_ly(node, rng)
     ts.title.add_face(faces.TextFace("Drawing your own Qt Faces", fsize=15), 0)
     return t, ts
 

--- a/tests/test_treeview/seq_motif_faces.py
+++ b/tests/test_treeview/seq_motif_faces.py
@@ -27,11 +27,14 @@ def layout(node):
         add_face_to_node(seqFace, node, 0, position="aligned")
 
 
-def get_example_tree():
+def get_example_tree(rng=None):
     # Create a random tree and add to each leaf a random set of motifs
     # from the original set
+    if rng is None:
+        import random
+        rng = random
     t = Tree()
-    t.populate(10)
+    t.populate(10, dist_fn=rng.random, support_fn=rng.random)
     # for l in t.iter_leaves():
     #     seq_motifs = [list(m) for m in motifs] #sample(motifs, randint(2, len(motifs)))
 

--- a/tests/test_treeview/test_all_treeview.py
+++ b/tests/test_treeview/test_all_treeview.py
@@ -1,7 +1,11 @@
-import unittest
-import sys
 import os
+import sys
 import random
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("PyQt6")
 
 ETEPATH = os.path.abspath(os.path.split(os.path.realpath(__file__))[0]+'/../')
 sys.path.insert(0, ETEPATH)
@@ -23,147 +27,153 @@ except ImportError:  # when run with unittest or pytest
 
 
 CONT = 0
-class Test_Core_Treeview(unittest.TestCase):
-    """ Tests tree basics. """
-    def test_renderer(self):
 
-        main_tree = Tree()
-        main_tree.dist = 0
 
-        t, ts = face_grid.get_example_tree()
-        t_grid = TreeFace(t, ts)
-        n = main_tree.add_child()
-        n.add_face(t_grid, 0, "aligned")
+@pytest.mark.parametrize("seed", [0, 1])
+def test_renderer(seed, tmp_path: Path):
+    random.seed(seed)
+    rng = random.Random(seed)
 
-        t, ts = bubble_map.get_example_tree()
-        t_bubble = TreeFace(t, ts)
-        n = main_tree.add_child()
-        n.add_face(t_bubble, 0, "aligned")
-        t.show()
+    main_tree = Tree()
+    main_tree.dist = 0
 
-        t, ts = item_faces.get_example_tree()
-        t_items = TreeFace(t, ts)
-        n = main_tree.add_child()
-        n.add_face(t_items, 0, "aligned")
+    t, ts = face_grid.get_example_tree()
+    t_grid = TreeFace(t, ts)
+    n = main_tree.add_child()
+    n.add_face(t_grid, 0, "aligned")
 
-        t, ts = node_style.get_example_tree()
-        t_nodest = TreeFace(t, ts)
-        n = main_tree.add_child()
-        n.add_face(t_nodest, 0, "aligned")
+    t, ts = bubble_map.get_example_tree(rng)
+    t_bubble = TreeFace(t, ts)
+    n = main_tree.add_child()
+    n.add_face(t_bubble, 0, "aligned")
 
-        t, ts = node_background.get_example_tree()
-        t_bg = TreeFace(t, ts)
-        n = main_tree.add_child()
-        n.add_face(t_bg, 0, "aligned")
+    t, ts = item_faces.get_example_tree(rng)
+    t_items = TreeFace(t, ts)
+    n = main_tree.add_child()
+    n.add_face(t_items, 0, "aligned")
 
-        t, ts = face_positions.get_example_tree()
-        t_fpos = TreeFace(t, ts)
-        n = main_tree.add_child()
-        n.add_face(t_fpos, 0, "aligned")
+    t, ts = node_style.get_example_tree()
+    t_nodest = TreeFace(t, ts)
+    n = main_tree.add_child()
+    n.add_face(t_nodest, 0, "aligned")
 
-        t, ts = phylotree_visualization.get_example_tree()
-        t_phylo = TreeFace(t, ts)
-        n = main_tree.add_child()
-        n.add_face(t_phylo, 0, "aligned")
+    t, ts = node_background.get_example_tree()
+    t_bg = TreeFace(t, ts)
+    n = main_tree.add_child()
+    n.add_face(t_bg, 0, "aligned")
 
-        t, ts = face_rotation.get_example_tree()
-        temp_facet = TreeFace(t, ts)
-        n = main_tree.add_child()
-        n.add_face(temp_facet, 0, "aligned")
+    t, ts = face_positions.get_example_tree()
+    t_fpos = TreeFace(t, ts)
+    n = main_tree.add_child()
+    n.add_face(t_fpos, 0, "aligned")
 
-        t, ts = seq_motif_faces.get_example_tree()
-        temp_facet = TreeFace(t, ts)
-        n = main_tree.add_child()
-        n.add_face(temp_facet, 0, "aligned")
+    t, ts = phylotree_visualization.get_example_tree()
+    t_phylo = TreeFace(t, ts)
+    n = main_tree.add_child()
+    n.add_face(t_phylo, 0, "aligned")
 
-        t, ts = barchart_and_piechart_faces.get_example_tree()
-        temp_facet = TreeFace(t, ts)
-        n = main_tree.add_child()
-        n.add_face(temp_facet, 0, "aligned")
+    t, ts = face_rotation.get_example_tree(rng)
+    temp_facet = TreeFace(t, ts)
+    n = main_tree.add_child()
+    n.add_face(temp_facet, 0, "aligned")
 
-        #Test orphan nodes and trees with 0 branch length
-        t, ts = Tree(), TreeStyle()
-        t.populate(5)
-        for n in t.traverse():
-            n.dist = 0
-        temp_tface = TreeFace(t, ts)
-        n = main_tree.add_child()
-        n.add_face(temp_tface, 0, "aligned")
+    t, ts = seq_motif_faces.get_example_tree(rng)
+    temp_facet = TreeFace(t, ts)
+    n = main_tree.add_child()
+    n.add_face(temp_facet, 0, "aligned")
 
-        ts.optimal_scale_level = "full"
-        temp_tface = TreeFace(t, ts)
-        n = main_tree.add_child()
-        n.add_face(temp_tface, 0, "aligned")
+    t, ts = barchart_and_piechart_faces.get_example_tree(rng)
+    temp_facet = TreeFace(t, ts)
+    n = main_tree.add_child()
+    n.add_face(temp_facet, 0, "aligned")
 
-        ts = TreeStyle()
-        t.populate(5)
-        ts.mode = "c"
-        temp_tface = TreeFace(t, ts)
-        n = main_tree.add_child()
-        n.add_face(temp_tface, 0, "aligned")
+    #Test orphan nodes and trees with 0 branch length
+    t, ts = Tree(), TreeStyle()
+    t.populate(5)
+    for n in t.traverse():
+        n.dist = 0
+    temp_tface = TreeFace(t, ts)
+    n = main_tree.add_child()
+    n.add_face(temp_tface, 0, "aligned")
 
-        ts.optimal_scale_level = "full"
-        temp_tface = TreeFace(t, ts)
-        n = main_tree.add_child()
-        n.add_face(temp_tface, 0, "aligned")
+    ts.optimal_scale_level = "full"
+    temp_tface = TreeFace(t, ts)
+    n = main_tree.add_child()
+    n.add_face(temp_tface, 0, "aligned")
 
-        t, ts = Tree(), TreeStyle()
-        temp_tface = TreeFace(Tree('node;'), ts)
-        n = main_tree.add_child()
-        n.add_face(temp_tface, 0, "aligned")
+    ts = TreeStyle()
+    t.populate(5)
+    ts.mode = "c"
+    temp_tface = TreeFace(t, ts)
+    n = main_tree.add_child()
+    n.add_face(temp_tface, 0, "aligned")
 
-        t, ts = Tree(), TreeStyle()
-        ts.mode = "c"
-        temp_tface = TreeFace(Tree('node;'), ts)
-        n = main_tree.add_child()
-        n.add_face(temp_tface, 0, "aligned")
+    ts.optimal_scale_level = "full"
+    temp_tface = TreeFace(t, ts)
+    n = main_tree.add_child()
+    n.add_face(temp_tface, 0, "aligned")
 
-        t, ts = Tree(), TreeStyle()
-        ts.mode = "c"
-        temp_tface = TreeFace(Tree(), ts)
-        n = main_tree.add_child()
-        n.add_face(temp_tface, 0, "aligned")
+    t, ts = Tree(), TreeStyle()
+    temp_tface = TreeFace(Tree('node;'), ts)
+    n = main_tree.add_child()
+    n.add_face(temp_tface, 0, "aligned")
 
-        t, ts = Tree(), TreeStyle()
-        temp_tface = TreeFace(Tree(), ts)
-        n = main_tree.add_child()
-        n.add_face(temp_tface, 0, "aligned")
+    t, ts = Tree(), TreeStyle()
+    ts.mode = "c"
+    temp_tface = TreeFace(Tree('node;'), ts)
+    n = main_tree.add_child()
+    n.add_face(temp_tface, 0, "aligned")
 
-        # TEST TIGHT TEST WRAPPING
-        chars = ["." "p", "j", "jJ"]
-        def layout(node):
-            global CONT
-            if CONT >= len(chars):
-                CONT = 0
-            if node.is_leaf:
-                node.img_style["size"] = 0
-                F2= AttrFace("name", tight_text=True)
-                F= TextFace(chars[CONT], tight_text=True)
-                F.inner_border.width = 0
-                F2.inner_border.width = 0
-                #faces.add_face_to_node(F ,node, 0, position="branch-right")
-                faces.add_face_to_node(F2 ,node, 1, position="branch-right")
-                CONT += 1
-        t = Tree()
-        t.populate(20, dist_fn=random.random, support_fn=random.random)
-        ts = TreeStyle()
-        ts.layout_fn = layout
-        ts.mode = "c"
-        ts.show_leaf_name = False
+    t, ts = Tree(), TreeStyle()
+    ts.mode = "c"
+    temp_tface = TreeFace(Tree(), ts)
+    n = main_tree.add_child()
+    n.add_face(temp_tface, 0, "aligned")
 
-        temp_tface = TreeFace(t, ts)
-        n = main_tree.add_child()
-        n.add_face(temp_tface, 0, "aligned")
+    t, ts = Tree(), TreeStyle()
+    temp_tface = TreeFace(Tree(), ts)
+    n = main_tree.add_child()
+    n.add_face(temp_tface, 0, "aligned")
 
-        # MAIN TREE
+    # TEST TIGHT TEST WRAPPING
+    chars = ["." "p", "j", "jJ"]
+    def layout(node):
+        global CONT
+        if CONT >= len(chars):
+            CONT = 0
+        if node.is_leaf:
+            node.img_style["size"] = 0
+            F2= AttrFace("name", tight_text=True)
+            F= TextFace(chars[CONT], tight_text=True)
+            F.inner_border.width = 0
+            F2.inner_border.width = 0
+            #faces.add_face_to_node(F ,node, 0, position="branch-right")
+            faces.add_face_to_node(F2 ,node, 1, position="branch-right")
+            CONT += 1
+    t = Tree()
+    t.populate(20, dist_fn=rng.random, support_fn=rng.random)
+    ts = TreeStyle()
+    ts.layout_fn = layout
+    ts.mode = "c"
+    ts.show_leaf_name = False
 
-        ms = TreeStyle()
-        ms.mode = "r"
-        ms.show_leaf_name = False
-        main_tree.render('test.png', tree_style=ms)
-        main_tree.render('test.svg', tree_style=ms)
-        main_tree.render('test.pdf', tree_style=ms)
+    temp_tface = TreeFace(t, ts)
+    n = main_tree.add_child()
+    n.add_face(temp_tface, 0, "aligned")
+
+    # MAIN TREE
+
+    ms = TreeStyle()
+    ms.mode = "r"
+    ms.show_leaf_name = False
+    main_tree.render(str(tmp_path / 'test.png'), tree_style=ms)
+    svg_path = tmp_path / 'test.svg'
+    main_tree.render(str(svg_path), tree_style=ms)
+    main_tree.render(str(tmp_path / 'test.pdf'), tree_style=ms)
+
+    assert svg_path.exists() and svg_path.stat().st_size > 0
 
 
 if __name__ == '__main__':
-    unittest.main()
+    import sys
+    sys.exit(pytest.main([__file__]))

--- a/tests/test_treeview/tree_faces.py
+++ b/tests/test_treeview/tree_faces.py
@@ -6,14 +6,14 @@ small_ts = TreeStyle()
 small_ts.show_leaf_name = True
 small_ts.scale = 10
 
-def layout(node):
+def layout(node, rng):
     if node.is_leaf:
-        # Add node name to laef nodes
+        # Add node name to leaf nodes
         N = AttrFace("name", fsize=14, fgcolor="black")
         faces.add_face_to_node(N, node, 0)
 
         t = Tree()
-        t.populate(10)
+        t.populate(10, dist_fn=rng.random, support_fn=rng.random)
 
         T = TreeFace(t, small_ts)
         # Let's make the sphere transparent
@@ -21,20 +21,22 @@ def layout(node):
         # And place as a float face over the tree
         faces.add_face_to_node(T, node, 1, position="aligned")
 
-def get_example_tree():
+def get_example_tree(rng=None):
+    if rng is None:
+        rng = random
     # Random tree
     t = Tree()
-    t.populate(20, dist_fn=random.random, support_fn=random.random)
+    t.populate(20, dist_fn=rng.random, support_fn=rng.random)
 
     # Some random properties in all nodes
     for n in t.traverse():
-        n.add_properties(weight=random.randint(0, 50))
+        n.add_properties(weight=rng.randint(0, 50))
 
     # Create an empty TreeStyle
     ts = TreeStyle()
 
     # Set our custom layout function
-    ts.layout_fn = layout
+    ts.layout_fn = lambda node: layout(node, rng)
 
     # Draw a tree
     ts.mode = "c"


### PR DESCRIPTION
## Summary
- Allow passing a `random.Random` instance to treeview example helpers
- Make treeview renderer test use temporary files, verify SVG output, and skip when PyQt6 is unavailable
- Inject RNG into remaining treeview examples for deterministic seeding

## Testing
- `./run_tests.py -i` *(libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a84f9d84832a88e41f3e94ab8069