### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install cython bottle cheroot brotli numpy scipy pytest
+          pip install -e .[treeview,test,doc,render_sm,treediff]
+
+      - name: Run tests
+        run: |
+          pytest -m "not interactive and not slow"


### PR DESCRIPTION
## Summary
- add GitHub Actions CI matrix for Python 3.9-3.12 with pip caching
- install dependencies via pip and run non-interactive, non-slow pytest suite

## Testing
- `pip install cython bottle cheroot brotli numpy scipy pytest`
- `pip install -e .[treeview,test,doc,render_sm,treediff]`
- `apt-get install -y libgl1`
- `pytest -m "not interactive and not slow"` *(fails: 27 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b6705508832aa4e83abb0f61aeb9