### PR TITLE
docs: add PyQt6 system dependencies to AGENTS instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,7 @@
 ## Environment Setup
   - Clone the repository.
   - Install required build dependencies with conda: `conda install -c conda-forge cython bottle cheroot brotli numpy scipy pytest`.
+  - Install PyQt6 system dependencies: `sudo apt-get install -y libgl1 libegl1`.
   - Alwayes install full suite via `pip install -e .[treeview,test,doc,render_sm,treediff]`.
 
 ## Testing


### PR DESCRIPTION
## Summary
- document installing libgl1 and libegl1 for PyQt6 in environment setup

## Testing
- `pytest -m "not slow and not interactive"` *(fails: ModuleNotFoundError: No module named 'six'; cannot import name 'CircleFace')*

------
https://chatgpt.com/codex/tasks/task_e_68b1c1282860832a849ebc2719ab8fbf