### PR TITLE
ci: install external apps via conda

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,30 @@ jobs:
 
       - name: Install external executables
         run: |
-          conda install -y -c etetoolkit -c conda-forge gcc \
-            DIALIGN-TX_1.0.2 Duptree FastTree2 T-COFFEE_distribution_Version_11.00.8cbe486 \
-            argtable2-13 clustal-omega-1.2.1 consel iqtree-omp-1.4.2-Linux \
-            iqtree-omp-1.4.2-MacOSX kalign-2.03 mafft-6.861-without-extensions muscle3.8.31 \
-            paml4.8 phylobayes4.1c phyml-20120412-patched pmodeltest prank-100802 \
-            probcons-1.12 slr standard-RAxML-8.2.8 treebest trimal-1.4
+          conda config --add channels bioconda
+          conda config --add channels conda-forge
+          conda config --set channel_priority strict
+          conda install -y -c conda-forge mamba
+          mamba install -y -c bioconda dialign-tx=1.0.2
+          # DupTree is not available via conda or pip; build from source if needed
+          mamba install -y -c bioconda fasttree
+          mamba install -y -c bioconda t-coffee=11.00.8cbe486
+          mamba install -y -c conda-forge argtable2=2.13
+          mamba install -y -c bioconda clustalo=1.2.4
+          mamba install -y -c bioconda consel
+          mamba install -y -c bioconda iqtree=1.6.12
+          mamba install -y -c bioconda kalign2=2.04
+          mamba install -y -c bioconda mafft
+          mamba install -y -c bioconda muscle=3.8.1551
+          mamba install -y -c bioconda paml
+          mamba install -y -c bioconda phylobayes-mpi
+          mamba install -y -c bioconda phyml
+          mamba install -y -c etetoolkit pmodeltest
+          mamba install -y -c bioconda prank
+          mamba install -y -c bioconda probcons=1.12
+          mamba install -y -c bioconda raxml=8.2.13
+          mamba install -y -c bioconda treebest
+          mamba install -y -c bioconda trimal=1.5.0
         shell: bash -l {0}
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,28 +25,31 @@ jobs:
         run: |
           conda config --add channels bioconda
           conda config --add channels conda-forge
+          conda config --add channels etetoolkit
           conda config --set channel_priority strict
-          conda install -y -c conda-forge mamba
-          mamba install -y -c bioconda dialign-tx=1.0.2
+          conda install -y \
+            dialign-tx=1.0.2 \
+            fasttree \
+            t-coffee=11.00.8cbe486 \
+            argtable2=2.13 \
+            clustalo=1.2.4 \
+            consel \
+            iqtree=1.6.12 \
+            kalign2=2.04 \
+            mafft \
+            muscle=3.8.1551 \
+            paml \
+            phylobayes-mpi \
+            phyml \
+            pmodeltest \
+            prank \
+            probcons=1.12 \
+            raxml=8.2.13 \
+            treebest \
+            trimal=1.5.0 \
+            ete3_external_apps \
+            gcc
           # DupTree is not available via conda or pip; build from source if needed
-          mamba install -y -c bioconda fasttree
-          mamba install -y -c bioconda t-coffee=11.00.8cbe486
-          mamba install -y -c conda-forge argtable2=2.13
-          mamba install -y -c bioconda clustalo=1.2.4
-          mamba install -y -c bioconda consel
-          mamba install -y -c bioconda iqtree=1.6.12
-          mamba install -y -c bioconda kalign2=2.04
-          mamba install -y -c bioconda mafft
-          mamba install -y -c bioconda muscle=3.8.1551
-          mamba install -y -c bioconda paml
-          mamba install -y -c bioconda phylobayes-mpi
-          mamba install -y -c bioconda phyml
-          mamba install -y -c etetoolkit pmodeltest
-          mamba install -y -c bioconda prank
-          mamba install -y -c bioconda probcons=1.12
-          mamba install -y -c bioconda raxml=8.2.13
-          mamba install -y -c bioconda treebest
-          mamba install -y -c bioconda trimal=1.5.0
         shell: bash -l {0}
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,13 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install external executables
-        run: conda install -y -c etetoolkit -c conda-forge gcc ete3_external_apps
+        run: |
+          conda install -y -c etetoolkit -c conda-forge gcc \
+            DIALIGN-TX_1.0.2 Duptree FastTree2 T-COFFEE_distribution_Version_11.00.8cbe486 \
+            argtable2-13 clustal-omega-1.2.1 consel iqtree-omp-1.4.2-Linux \
+            iqtree-omp-1.4.2-MacOSX kalign-2.03 mafft-6.861-without-extensions muscle3.8.31 \
+            paml4.8 phylobayes4.1c phyml-20120412-patched pmodeltest prank-100802 \
+            probcons-1.12 slr standard-RAxML-8.2.8 treebest trimal-1.4
         shell: bash -l {0}
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,16 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgl1 libegl1
+          sudo apt-get install -y libgl1 libegl1 libxkbcommon0
+
+      - name: Install Miniconda
+        run: |
+          wget -qO miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+          bash miniconda.sh -b -p $HOME/miniconda
+          echo "$HOME/miniconda/bin" >> $GITHUB_PATH
+
+      - name: Install external executables
+        run: conda install -y -c etetoolkit ete3_external_apps
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,6 @@ jobs:
             raxml=8.2.13 \
             treebest \
             trimal=1.5.0 \
-            ete3_external_apps \
             gcc
           # DupTree is not available via conda or pip; build from source if needed
           # pmodeltest is Python 2 only and is omitted

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,27 +16,23 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgl1 libegl1 libxkbcommon0
 
-      - name: Install Miniconda
-        run: |
-          wget -qO miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
-          bash miniconda.sh -b -p $HOME/miniconda
-          echo "$HOME/miniconda/bin" >> $GITHUB_PATH
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+          auto-update-conda: true
+          python-version: ${{ matrix.python-version }}
 
       - name: Install external executables
-        run: conda install -y -c etetoolkit ete3_external_apps
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: 'pip'
+        run: conda install -y -c etetoolkit -c conda-forge gcc ete3_external_apps
+        shell: bash -l {0}
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install cython bottle cheroot brotli numpy scipy pytest
           pip install -e .[treeview,test,doc,render_sm,treediff]
+        shell: bash -l {0}
 
       - name: Run tests
         run: |
           pytest tests -m "not interactive and not slow"
+        shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,10 @@ jobs:
 
       - name: Install external executables
         run: |
-          conda config --add channels bioconda
+          conda config --remove channels defaults
           conda config --add channels conda-forge
+          conda config --add channels bioconda
           conda config --add channels etetoolkit
-          conda config --set channel_priority strict
           conda install -y \
             dialign-tx=1.0.2 \
             fasttree \
@@ -41,7 +41,6 @@ jobs:
             paml \
             phylobayes-mpi \
             phyml \
-            pmodeltest \
             prank \
             probcons=1.12 \
             raxml=8.2.13 \
@@ -50,6 +49,7 @@ jobs:
             ete3_external_apps \
             gcc
           # DupTree is not available via conda or pip; build from source if needed
+          # pmodeltest is Python 2 only and is omitted
         shell: bash -l {0}
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- install Miniconda in CI
- fetch ete3_external_apps via conda
- add libxkbcommon0 system dependency for Qt support

## Testing
- `pytest -m "not slow and not interactive" tests` *(fails: Fatal Python error: Aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d0c635d0832ab8416f1954c8af0d