### PR TITLE
ci: cache pip and split install steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,24 @@ jobs:
           
       - uses: actions/checkout@v4
 
-      - name: Install dependencies
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-
+
+      - name: Install pip dependencies
         run: |
           pip install cython bottle cheroot brotli numpy scipy pytest
+
+      - name: Install ete
+        run: |
           pip install -e .[treeview,test,doc,render_sm,treediff]
       
 


### PR DESCRIPTION
## Summary
- cache pip dependencies per Python version
- install dependencies and project separately

## Testing
- `pytest -m "not slow and not interactive"`


------
https://chatgpt.com/codex/tasks/task_e_68b22645d66c832a940622a42873e39e